### PR TITLE
- Api for setting and getting user information

### DIFF
--- a/src/main/java/ru/catstack/auth/controller/UpdateUserInfoController.java
+++ b/src/main/java/ru/catstack/auth/controller/UpdateUserInfoController.java
@@ -1,0 +1,87 @@
+package ru.catstack.auth.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import ru.catstack.auth.model.payload.request.setRequest.*;
+import ru.catstack.auth.model.payload.response.ApiResponse;
+import ru.catstack.auth.service.UserService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping(value = "/api/users/update/")
+public class UpdateUserInfoController {
+    private final UserService userService;
+
+    @Autowired
+    public UpdateUserInfoController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/setUsername")
+    public ApiResponse setUsername(@Valid @RequestBody SetUsername updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            var newToken = userService.updateUsernameById(user.getId(), updateInfo.getUsername());
+            return new ApiResponse(newToken);
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setFirstName")
+    public ApiResponse setFirstName(@Valid @RequestBody SetFirstName updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updateFirstNameById(user.getId(), updateInfo.getFirstName());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setLastName")
+    public ApiResponse setLastName(@Valid @RequestBody SetLastName updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updateLastNameById(user.getId(), updateInfo.getLastName());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setAge")
+    public ApiResponse setAge(@Valid @RequestBody SetAge updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updateAgeById(user.getId(), updateInfo.getAge());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setEmail")
+    public ApiResponse setEmail(@Valid @RequestBody SetEmail updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updateEmailById(user.getId(), updateInfo.getEmail());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setPassword")
+    public ApiResponse setPassword(@Valid @RequestBody SetPassword updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updatePasswordById(user.getId(), updateInfo.getPassword());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+
+    @PostMapping("/setAbout")
+    public ApiResponse setAboutMe(@Valid @RequestBody SetAboutMe updateInfo) {
+        var loggedUser = userService.getLoggedInUser();
+        return loggedUser.map(user -> {
+            userService.updateAboutMeById(user.getId(), updateInfo.getAbout());
+            return new ApiResponse("Information saved successfully");
+        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/controller/UserController.java
+++ b/src/main/java/ru/catstack/auth/controller/UserController.java
@@ -37,17 +37,5 @@ public class UserController {
             return new ApiResponse(userProfileData);
         }).orElseThrow(() -> new AccessDeniedException("An unexpected error occurred while trying to get user data"));
     }
-
-//    @PostMapping("/setAboutMe")
-//    @PreAuthorize("hasRole('USER_ROLE')")
-//    public ResponseEntity setAboutMe(@Valid @RequestBody SetUserInfoRequest userInfoRequest) {
-//        var loggedUser = getLoggedInUser();
-//        return loggedUser.map(user -> {
-//            var userProfileData = new UserProfileData(user.getId(), userInfoRequest.getAboutMe());
-//            UserProfileData savedData = userProfileDataService.save(userProfileData);
-//            return ResponseEntity.ok(new ApiSuccessResponse(true, "Information saved successfully"));
-//        }).orElseThrow(() -> new AccessDeniedException("Access denied for unauthenticated user"));
-//    }
-
 }
 

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetAboutMe.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetAboutMe.java
@@ -1,0 +1,28 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(value = "Update first name Request", description = "The update first name request payload")
+public class SetAboutMe {
+    @NotBlank(message = "About me cannot be blank")
+    @ApiModelProperty(value = "A valid about me info", required = true, allowableValues = "NonEmpty String")
+    @Length(min = 1, max = 500, message = "Text length must be greater than 0 and less than 500 characters")
+    private String about;
+
+    public SetAboutMe(String firstName) {
+        this.about = firstName;
+    }
+
+    public SetAboutMe() {
+
+    }
+
+    public String getAbout() {
+        return about;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetAge.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetAge.java
@@ -1,0 +1,28 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@ApiModel(value = "Update age Request", description = "The update age request payload")
+public class SetAge {
+    @ApiModelProperty(value = "A valid age", required = true)
+    @Min(value = 12, message = "Only users over 12 years old are allowed")
+    @Max(value = 127, message = "Age cannot be higher than 127 years")
+    private Integer age;
+
+    public SetAge(int firstName) {
+        this.age = firstName;
+    }
+
+    public SetAge() {
+
+    }
+
+    public byte getAge() {
+        return age.byteValue();
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetEmail.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetEmail.java
@@ -1,0 +1,28 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(value = "Update age Request", description = "The update age request payload")
+public class SetEmail {
+    @NotBlank(message = "Email cannot be blank")
+    @Email(message = "Email is not valid")
+    @ApiModelProperty(value = "A valid email", required = true, allowableValues = "NonEmpty String")
+    private String email;
+
+    public SetEmail(String firstName) {
+        this.email = firstName;
+    }
+
+    public SetEmail() {
+
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetFirstName.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetFirstName.java
@@ -1,0 +1,27 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javafx.concurrent.Service;
+
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(value = "Update first name Request", description = "The update first name request payload")
+public class SetFirstName {
+    @NotBlank(message = "First name cannot be blank")
+    @ApiModelProperty(value = "A valid first name", required = true, allowableValues = "NonEmpty String")
+    private String firstName;
+
+    public SetFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public SetFirstName() {
+
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetLastName.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetLastName.java
@@ -1,0 +1,26 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(value = "Update last name Request", description = "The update last name request payload")
+public class SetLastName {
+    @NotBlank(message = "Last name cannot be blank")
+    @ApiModelProperty(value = "A valid last name", required = true, allowableValues = "NonEmpty String")
+    private String lastName;
+
+    public SetLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public SetLastName() {
+
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetPassword.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetPassword.java
@@ -1,0 +1,28 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(value = "Update age Request", description = "The update age request payload")
+public class SetPassword {
+    @NotBlank(message = "Password cannot be blank")
+    @Length(min = 8, max = 50, message = "Password length must be between 8 and 50 characters")
+    @ApiModelProperty(value = "A valid password string", required = true, allowableValues = "NonEmpty String")
+    private String password;
+
+    public SetPassword(String firstName) {
+        this.password = firstName;
+    }
+
+    public SetPassword() {
+
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetUsername.java
+++ b/src/main/java/ru/catstack/auth/model/payload/request/setRequest/SetUsername.java
@@ -1,0 +1,28 @@
+package ru.catstack.auth.model.payload.request.setRequest;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.*;
+
+@ApiModel(value = "Update username Request", description = "The update username request payload")
+public class SetUsername {
+    @NotBlank(message = "Username cannot be blank")
+    @NotNull(message = "Username cannot be null")
+    @Pattern(regexp = "[a-zA-Z0-9]{2,30}", message = "The username can only include uppercase and lowercase letters of the English alphabet and numbers and length must be between 2 and 30 character")
+    @ApiModelProperty(value = "A valid username", required = true, allowableValues = "NonEmpty String")
+    private String username;
+
+    public SetUsername(String newUsername) {
+        this.username = newUsername;
+    }
+
+    public SetUsername() {
+
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}
+

--- a/src/main/java/ru/catstack/auth/model/token/RefreshToken.java
+++ b/src/main/java/ru/catstack/auth/model/token/RefreshToken.java
@@ -21,7 +21,7 @@ public class RefreshToken extends DateAudit {
     @NaturalId(mutable = true)
     private String token;
 
-    @OneToOne(fetch=FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch=FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name="session_id")
     private Session session;
 

--- a/src/main/java/ru/catstack/auth/repository/UserRepository.java
+++ b/src/main/java/ru/catstack/auth/repository/UserRepository.java
@@ -16,40 +16,40 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String name);
     Optional<User> findByEmail(String email);
 
-    @Modifying
+
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.username = :username WHERE c.id = :id")
     void updateUsernameById(@Param("id") Long id, @Param("username") String username);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.firstName = :firstName WHERE c.id = :id")
     void updateFirstNameById(@Param("id") Long id, @Param("firstName") String firstName);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.lastName = :lastName WHERE c.id = :id")
     void updateLastNameById(@Param("id") Long id, @Param("lastName") String lastName);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.age = :age WHERE c.id = :id")
     void updateAgeById(@Param("id") Long id, @Param("age") Byte age);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.email = :email WHERE c.id = :id")
     void updateEmailById(@Param("id") Long id, @Param("email") String email);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.password = :password WHERE c.id = :id")
     void updatePasswordById(@Param("id") Long id, @Param("password") String password);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.aboutMe = :aboutMe WHERE c.id = :id")
-    void setAboutMeById(@Param("id") Long id, @Param("aboutMe") String aboutMe);
+    void updateAboutMeById(@Param("id") Long id, @Param("aboutMe") String aboutMe);
 
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.updatedAt = :updatedAt WHERE c.id = :id")
     void setUpdatedAtById(@Param("id") Long id, @Param("updatedAt") Instant updatedAt);
 
-    @Transactional
-    @Modifying
+    @Transactional @Modifying
     @Query("UPDATE User c SET c.hasPicture = :hasPicture WHERE c.id = :id")
     void updateHasPictureById(@Param("id") Long id, @Param("hasPicture") boolean hasPicture);
 

--- a/src/main/java/ru/catstack/auth/security/JwtUserDetailsService.java
+++ b/src/main/java/ru/catstack/auth/security/JwtUserDetailsService.java
@@ -30,4 +30,11 @@ public class JwtUserDetailsService implements UserDetailsService {
         return dbUser.map(JwtUserFactory::create)
                 .orElseThrow(() -> new UsernameNotFoundException("Couldn't find a matching user name in the database for " + username));
     }
+
+    public UserDetails loadById(long id) throws UsernameNotFoundException {
+        Optional<User> dbUser = userRepository.findById(id);
+        logger.info("Fetched user : " + dbUser + " by " + id);
+        return dbUser.map(JwtUserFactory::create)
+                .orElseThrow(() -> new UsernameNotFoundException("Couldn't find a matching user name in the database for " + id));
+    }
 }

--- a/src/main/java/ru/catstack/auth/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/ru/catstack/auth/security/jwt/JwtTokenFilter.java
@@ -1,26 +1,13 @@
 package ru.catstack.auth.security.jwt;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.filter.OncePerRequestFilter;
 import ru.catstack.auth.exception.InvalidJwtTokenException;
-import ru.catstack.auth.exception.JwtAuthenticationException;
-import ru.catstack.auth.security.JwtUserDetailsService;
-import ru.catstack.auth.service.UserService;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -41,7 +28,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             String token = jwtTokenProvider.resolveToken(request);
 
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-                Long userId = jwtTokenProvider.getUserIdFromToken(token);
+                Long userId = jwtTokenProvider.getUserId(token);
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }


### PR DESCRIPTION
Added processing of authorized POST requests for changing various user parameters:
/api/users/update
     /setUsername
     /setFirstName
     /setLastName
     /setPassword
     /setEmail
     /setAge
     /setAbout
In the request body, a JSON object is passed with the field that is being changed and its new value, as in the example:
`{
	"about": "about me"
}`

Request example:
```
POST /api/users/update/setAbout HTTP/1.1
Host: localhost:8075
Authorization: Bearer eyJhbGc.....WXNHaJQ
Content-Type: application/json

{
	"about": "poshel nahui"
}
```